### PR TITLE
Fix CAN FD bitrate switching

### DIFF
--- a/pycyphal/transport/can/media/pythoncan/_pythoncan.py
+++ b/pycyphal/transport/can/media/pythoncan/_pythoncan.py
@@ -300,6 +300,7 @@ class PythonCANMedia(Media):
                 is_extended_id=(f.frame.format == FrameFormat.EXTENDED),
                 data=f.frame.data,
                 is_fd=self._is_fd,
+                bitrate_switch=self._is_fd,
             )
             try:
                 desired_timeout = monotonic_deadline - loop.time()


### PR DESCRIPTION
Set the BRS bit for pythoncan transports when the interface operates in CAN FD mode.

Fixes https://github.com/OpenCyphal/pycyphal/issues/368